### PR TITLE
Refactor CI workflow to only trigger on push or pull request for the main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,13 @@
 
 name: CI
 
-on: [ push, pull_request ]
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+        branches:
+            - main
 
 jobs:
     analyze-static-shellcheck:


### PR DESCRIPTION
Resolves #26.

The CI workflow previously triggered on push or pull request to any
branch. This resulted in duplicate job runs when a project maintainer
pushed to a feature branch that had a pull request associated with it.