### PR TITLE
Use PROJECT_SOURCE_DIR instead of CMAKE_CURRENT_SOURCE_DIR where appropriate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ project( cmake-utilities
     LANGUAGES NONE
     )
 
-list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" )
+list( APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}" )
 include( git-utilities )
 include( lcov-utilities )
 include( plantuml-utilities )


### PR DESCRIPTION
Resolves #85 (Use PROJECT_SOURCE_DIR instead of CMAKE_CURRENT_SOURCE_DIR where appropriate).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring
- [ ] Performs a repository administrative action

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.
